### PR TITLE
Fixed missing conda-forge channel in requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,8 @@
 name: opsd_time_series
 
+channels:
+  - conda-forge
+
 dependencies:
   - python=3.6
   - pandas
@@ -13,3 +16,4 @@ dependencies:
   - requests
   - jupyter_contrib_nbextensions  # nice add-ons for jupyter
   - selenium  # required to scrape URLs from Terna website
+  - paramiko


### PR DESCRIPTION
When I follow the installation guide [[1](https://github.com/Open-Power-System-Data/common/wiki/Tutorial-to-run-OPSD-scripts)] to set up the conda environment jupyter_contrib_nbextensions isn't installed because of:
```
Collecting package metadata (repodata.json): done
Solving environment: failed

ResolvePackageNotFound:
    - jupyter_contrib_nbextensions 
```
This happens because the package is only availabe via the conda-forge channel. See ipython-contrib GitHub -> Installation -> Conda -> conda install *-c conda-forge* jupyter_contrib_nbextensions [[2](https://github.com/ipython-contrib/jupyter_contrib_nbextensions)].

Also when running the processing notebook 'paramiko' is missing. So I added it to the requirements.yml.

[1] https://github.com/Open-Power-System-Data/common/wiki/Tutorial-to-run-OPSD-scripts
[2] https://github.com/ipython-contrib/jupyter_contrib_nbextensions